### PR TITLE
Add support for array types

### DIFF
--- a/assign_test.go
+++ b/assign_test.go
@@ -44,13 +44,11 @@ func TestAssignToAllFields(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				ex := f.Interface()
 				ac := acAll.Field(i).Interface()
-
 				v := ValueOf(ex)
 				err := v.AssignTo(&ac)
 				if err != nil {
 					t.Errorf("unexpected error: %+v\n", err)
 				}
-
 				if !reflect.DeepEqual(ex, ac) {
 					t.Errorf("expected: %+v but found: %+v\n", ex, ac)
 				}
@@ -138,6 +136,12 @@ type All struct {
 	EmptySlice []Small
 	NilSlice   []Small
 
+	Array      [2]Small
+	ArrayP     [2]*Small
+	PArray     *[2]Small
+	PArrayP    *[2]*Small
+	EmptyArray [0]Small
+
 	StringSlice []string
 	ByteSlice   []byte
 
@@ -186,6 +190,10 @@ var allValue = All{
 	Slice:       []Small{{Tag: "tag20", Field: "field20"}, {Tag: "tag21", Field: "field21"}},
 	SliceP:      []*Small{{Tag: "tag22", Field: "field22"}, {Tag: "tag23", Field: "field23"}},
 	EmptySlice:  []Small{},
+	Array:       [2]Small{{Tag: "tag20", Field: "field20"}, {Tag: "tag21", Field: "field21"}},
+	ArrayP:      [2]*Small{{Tag: "tag20", Field: "field20"}, {Tag: "tag21", Field: "field21"}},
+	PArray:      &[2]Small{{Tag: "tag20", Field: "field20"}, {Tag: "tag21", Field: "field21"}},
+	PArrayP:     &[2]*Small{{Tag: "tag20", Field: "field20"}, {Tag: "tag21", Field: "field21"}},
 	StringSlice: []string{"str24", "str25", "str26"},
 	ByteSlice:   []byte{27, 28, 29},
 	Small:       Small{Tag: "tag30", Field: "field30"},
@@ -244,7 +252,6 @@ func TestInvalidAssignmentJsToGoError(t *testing.T) {
 		{"object to int", object.New(), 0, &InvalidAssignmentError{Type: js.TypeObject, Kind: reflect.Int}},
 		{"object to float", object.New(), 0.0, &InvalidAssignmentError{Type: js.TypeObject, Kind: reflect.Float64}},
 		{"object to complex", object.New(), 0i, &InvalidAssignmentError{Type: js.TypeObject, Kind: reflect.Complex128}},
-		{"object to array", object.New(), [0]struct{}{}, &InvalidAssignmentError{Type: js.TypeObject, Kind: reflect.Array}},
 		{"object to channel", object.New(), make(chan struct{}), &InvalidAssignmentError{Type: js.TypeObject, Kind: reflect.Chan}},
 		{"object to func", object.New(), func() {}, &InvalidAssignmentError{Type: js.TypeObject, Kind: reflect.Func}},
 		{"object to nil interface", object.New(), i, &InvalidAssignmentError{Type: js.TypeObject, Kind: reflect.Interface}},

--- a/value.go
+++ b/value.go
@@ -40,8 +40,10 @@ func valueOf(v reflect.Value) js.Value {
 	switch v.Kind() {
 	case reflect.Ptr, reflect.Interface:
 		return valueOfPointerOrInterface(v)
-	case reflect.Slice, reflect.Array:
-		return valueOfSliceOrArray(v)
+	case reflect.Slice:
+		return valueOfSlice(v)
+	case reflect.Array:
+		return valueOfArray(v)
 	case reflect.Map:
 		return valueOfMap(v)
 	case reflect.Struct:
@@ -59,11 +61,16 @@ func valueOfPointerOrInterface(v reflect.Value) js.Value {
 	return valueOf(v.Elem())
 }
 
-// valueOfSliceOrArray returns a new array object value.
-func valueOfSliceOrArray(v reflect.Value) js.Value {
+// valueOfSlice returns a new array object value.
+func valueOfSlice(v reflect.Value) js.Value {
 	if v.IsNil() {
 		return null
 	}
+	return valueOfArray(v)
+}
+
+// valueOfArray returns a new array object value.
+func valueOfArray(v reflect.Value) js.Value {
 	a := array.New()
 	n := v.Len()
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
This PR adds support for array types in `AssignTo` and `ValueOf`. Prior to this PR:

- Passing an array into `ValueOf` would result in `panic: reflect: call of reflect.Value.IsNil on array Value`.
- Passing an array into `AssignTo` would result in `invalid assignment from JS type: object to Go kind: array`.