### PR TITLE
remove js.Wrapper and add time.Time convenience function

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.16.x, 1.17.x, 1.18.x, 1.19.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
       - name: Install chrome
@@ -17,7 +17,7 @@ jobs:
       - name: Install wasmbrowsertest
         run: go install github.com/agnivade/wasmbrowsertest@latest
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Test
         env:
           GOOS: js

--- a/README.md
+++ b/README.md
@@ -103,4 +103,3 @@ Package `vert` leverages and extends `syscall/js` to accommodate these shortcomi
 
 ## License
 * [MIT License](LICENSE)
-

--- a/README.md
+++ b/README.md
@@ -103,3 +103,4 @@ Package `vert` leverages and extends `syscall/js` to accommodate these shortcomi
 
 ## License
 * [MIT License](LICENSE)
+

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/norunners/vert
 
 go 1.16
 
-require github.com/corbym/gocrest v1.0.5 // indirect
+require github.com/corbym/gocrest v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/norunners/vert
 
 go 1.16
+
+require github.com/corbym/gocrest v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/corbym/gocrest v1.0.5 h1:6FUvLjKkKQ2hwMel8OKIZqN3slYEOHIFY9+lVaroFnU=
+github.com/corbym/gocrest v1.0.5/go.mod h1:lF3xBPnOU5DYDpa/vUq63SMxUhd5UAwGgmA8Z2pJ/Tk=

--- a/value.go
+++ b/value.go
@@ -38,6 +38,10 @@ func ValueOf(i interface{}) Value {
 
 // valueOf recursively returns a new value.
 func valueOf(v reflect.Value) js.Value {
+	if t, ok := v.Interface().(time.Time); ok {
+		dateConstructor := js.Global().Get("Date")
+		return dateConstructor.New(t.Format(time.RFC3339))
+	}
 	switch v.Kind() {
 	case reflect.Ptr, reflect.Interface:
 		return valueOfPointerOrInterface(v)
@@ -48,10 +52,6 @@ func valueOf(v reflect.Value) js.Value {
 	case reflect.Struct:
 		return valueOfStruct(v)
 	default:
-		if t, ok := v.Interface().(time.Time); ok {
-			dateConstructor := js.Global().Get("Date")
-			return dateConstructor.New(t.Format(time.RFC3339))
-		}
 		return js.ValueOf(v.Interface())
 	}
 }

--- a/value.go
+++ b/value.go
@@ -6,6 +6,7 @@ package vert
 import (
 	"reflect"
 	"syscall/js"
+	"time"
 )
 
 var (
@@ -47,6 +48,10 @@ func valueOf(v reflect.Value) js.Value {
 	case reflect.Struct:
 		return valueOfStruct(v)
 	default:
+		if t, ok := v.Interface().(time.Time); ok {
+			dateConstructor := js.Global().Get("Date")
+			return dateConstructor.New(t.Format(time.RFC3339))
+		}
 		return js.ValueOf(v.Interface())
 	}
 }

--- a/value.go
+++ b/value.go
@@ -27,7 +27,7 @@ func (v Value) JSValue() js.Value {
 // ValueOf returns the Go value as a new value.
 func ValueOf(i interface{}) Value {
 	switch i.(type) {
-	case nil, js.Value, js.Wrapper:
+	case nil, js.Value:
 		return Value{Value: js.ValueOf(i)}
 	default:
 		v := reflect.ValueOf(i)

--- a/value.go
+++ b/value.go
@@ -38,10 +38,6 @@ func ValueOf(i interface{}) Value {
 
 // valueOf recursively returns a new value.
 func valueOf(v reflect.Value) js.Value {
-	if t, ok := v.Interface().(time.Time); ok {
-		dateConstructor := js.Global().Get("Date")
-		return dateConstructor.New(t.Format(time.RFC3339))
-	}
 	switch v.Kind() {
 	case reflect.Ptr, reflect.Interface:
 		return valueOfPointerOrInterface(v)
@@ -95,6 +91,11 @@ func valueOfMap(v reflect.Value) js.Value {
 
 // valueOfStruct returns a new object value.
 func valueOfStruct(v reflect.Value) js.Value {
+	if t, ok := v.Interface().(time.Time); ok {
+		// special case: Time, instantiates a new js Date object
+		dateConstructor := js.Global().Get("Date")
+		return dateConstructor.New(t.Format(time.RFC3339))
+	}
 	t := v.Type()
 	s := object.New()
 	n := v.NumField()

--- a/value_test.go
+++ b/value_test.go
@@ -1,0 +1,22 @@
+package vert
+
+import (
+	"github.com/corbym/gocrest/is"
+	"github.com/corbym/gocrest/then"
+	"testing"
+	"time"
+)
+
+const isoStringLength = len("yyyy-MM-ddThh:mm:ss")
+
+func TestValueOfTime(t *testing.T) {
+	now := time.Now()
+
+	jsVal := ValueOf(now)
+
+	// cut of the timezone information, because seconds precision is sufficient for this test
+	jsValIsoString := jsVal.Call("toISOString").String()
+	jsValIsoString = jsValIsoString[:isoStringLength]
+
+	then.AssertThat(t, jsValIsoString, is.EqualTo(now.UTC().Format(time.RFC3339)[:isoStringLength]))
+}

--- a/value_test.go
+++ b/value_test.go
@@ -14,7 +14,7 @@ func TestValueOfTime(t *testing.T) {
 
 	jsVal := ValueOf(now)
 
-	// cut of the timezone information, because seconds precision is sufficient for this test
+	// cut off the timezone information, because second's precision is sufficient for this test
 	jsValIsoString := jsVal.Call("toISOString").String()
 	jsValIsoString = jsValIsoString[:isoStringLength]
 


### PR DESCRIPTION
Hi,

this is a great lib.  While tinkering around, I found two issues, I would like to share/improve.
This PR covers two aspects. 

* with Go 1.18, the js.Wrapper is no more available, so i removed it. See https://tip.golang.org/doc/go1.18
* for type time.Time, a "new Date" object in JS is created.

Any feedback is welcome.