### PR TITLE
upgrade actions/setup-go@v3 and actions/checkout@v3, because Github warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
       - name: Install chrome
@@ -17,7 +17,7 @@ jobs:
       - name: Install wasmbrowsertest
         run: go install github.com/agnivade/wasmbrowsertest@latest
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Test
         env:
           GOOS: js


### PR DESCRIPTION
This PR replaces one aspect of the #17 PR.

This PR fixes warnings in the Github Action, as described:
https://github.com/norunners/vert/pull/17#issuecomment-1320887148 