### PR TITLE
Fix go 1.19 js wrapper issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.16, 1.17, 1.18, 1.19]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/value.go
+++ b/value.go
@@ -27,7 +27,7 @@ func (v Value) JSValue() js.Value {
 // ValueOf returns the Go value as a new value.
 func ValueOf(i interface{}) Value {
 	switch i.(type) {
-	case nil, js.Value, js.Wrapper:
+	case nil, js.Value:
 		return Value{Value: js.ValueOf(i)}
 	default:
 		v := reflect.ValueOf(i)


### PR DESCRIPTION
This PR replaces one aspect of the #17 PR.

with Go 1.18, the js.Wrapper is no more available, so I removed it. See https://tip.golang.org/doc/go1.18

This will fix #16 