### PR TITLE
add convenience method for time.Time conversion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/norunners/vert
 
 go 1.16
+
+require github.com/corbym/gocrest v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/corbym/gocrest v1.0.5 h1:6FUvLjKkKQ2hwMel8OKIZqN3slYEOHIFY9+lVaroFnU=
+github.com/corbym/gocrest v1.0.5/go.mod h1:lF3xBPnOU5DYDpa/vUq63SMxUhd5UAwGgmA8Z2pJ/Tk=

--- a/value.go
+++ b/value.go
@@ -6,6 +6,7 @@ package vert
 import (
 	"reflect"
 	"syscall/js"
+	"time"
 )
 
 var (
@@ -90,6 +91,11 @@ func valueOfMap(v reflect.Value) js.Value {
 
 // valueOfStruct returns a new object value.
 func valueOfStruct(v reflect.Value) js.Value {
+	if t, ok := v.Interface().(time.Time); ok {
+		// special case: Time, instantiates a new js Date object
+		dateConstructor := js.Global().Get("Date")
+		return dateConstructor.New(t.Format(time.RFC3339))
+	}
 	t := v.Type()
 	s := object.New()
 	n := v.NumField()

--- a/value_test.go
+++ b/value_test.go
@@ -1,0 +1,22 @@
+package vert
+
+import (
+	"github.com/corbym/gocrest/is"
+	"github.com/corbym/gocrest/then"
+	"testing"
+	"time"
+)
+
+const isoStringLength = len("yyyy-MM-ddThh:mm:ss")
+
+func TestValueOfTime(t *testing.T) {
+	now := time.Now()
+
+	jsVal := ValueOf(now)
+
+	// cut of the timezone information, because seconds precision is sufficient for this test
+	jsValIsoString := jsVal.Call("toISOString").String()
+	jsValIsoString = jsValIsoString[:isoStringLength]
+
+	then.AssertThat(t, jsValIsoString, is.EqualTo(now.UTC().Format(time.RFC3339)[:isoStringLength]))
+}


### PR DESCRIPTION
This PR replaces one aspect of the #17 PR.

When converting time.Time objects, a "new Date" object in JS is created.
This is very convenient.

For testing only, this PR will introduce the https://github.com/corbym/gocrest library.
The library enables writing more readable code (clean code) by applying the hamcrest matcher style
